### PR TITLE
Fixed the removal of event listeners

### DIFF
--- a/DependencyInjection/HBStampieExtension.php
+++ b/DependencyInjection/HBStampieExtension.php
@@ -77,8 +77,9 @@ class HBStampieExtension extends \Symfony\Component\HttpKernel\DependencyInjecti
 
         if (!empty($config['delivery_address'])) {
             $container->getDefinition('hb_stampie.extra.listener.impersonate')
-                ->setAbstract(false)
                 ->replaceArgument(0, $config['delivery_address']);
+        } else {
+            $container->removeDefinition('hb_stampie.extra.listener.impersonate');
         }
 
         if (!$config['logging']) {

--- a/Resources/config/extra.xml
+++ b/Resources/config/extra.xml
@@ -28,10 +28,9 @@
 
         <!--
             Listeners:
-                These are abstract so that they are removed when they should not be activated.
-                 The DI extension will change them when activating them.
+                These are removed by the DI extension when they should not be activated.
         -->
-        <service id="hb_stampie.extra.listener.impersonate" class="%hb_stampie.extra.listener.impersonate.class%" abstract="true">
+        <service id="hb_stampie.extra.listener.impersonate" class="%hb_stampie.extra.listener.impersonate.class%">
             <!-- TODO switch to the kernel.event_subscriber tag when dropping the 2.0 support. -->
             <tag name="kernel.event_listener" event="stampie.pre_send" method="preSend" />
             <argument /><!-- delivery address -->


### PR DESCRIPTION
Making the listener abstract so that it is removed without being registered does not work anymore because Symfony now registers event listeners earlier than the removal. The bundle was using a hack working because of a bad behavior of FrameworkBundle (which was making debugging hard and so has been fixed)
So it is now registered in the dispatcher and then removed afetr that because it is abstract, thus breaking the mailer.

Please merge it ASAP as the bundle is now broken with the dev versions of Symfony 2.2, 2.3 and master
