### PR TITLE
take out data_collector from extra config

### DIFF
--- a/Resources/config/config.xml
+++ b/Resources/config/config.xml
@@ -17,5 +17,10 @@
             <tag name="console.command" command="stampie:test" />
             <argument type="service" id="stampie.mailer" />
         </service>
+
+        <service id="stampie.data_collector" class="Stampie\StampieBundle\DataCollector\StampieDataCollector" public="false">
+            <argument type="service" id="stampie.listener.message_logger" on-invalid="ignore" />
+            <tag name="data_collector" id="stampie" template="@Stampie/Collector/messages.html.twig"/>
+        </service>
     </services>
 </container>

--- a/Resources/config/extra.xml
+++ b/Resources/config/extra.xml
@@ -10,11 +10,6 @@
             <argument type="service" id="event_dispatcher" />
         </service>
 
-        <service id="stampie.data_collector" class="Stampie\StampieBundle\DataCollector\StampieDataCollector" public="false">
-            <argument type="service" id="stampie.listener.message_logger" on-invalid="ignore" />
-            <tag name="data_collector" id="stampie" template="@Stampie/Collector/messages.html.twig"/>
-        </service>
-
         <!--
             Listeners:
                 These are removed by the DI extension when they should not be activated.


### PR DESCRIPTION
take out data_collector from extra config, because data_collector is part of the bundle itself.
current config needs to require `stampie/extra` to view the `Stampie E-Mails` at the profiler