### PR TITLE
Fix the CI setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,15 +17,18 @@ matrix:
         - php: 7.2
           env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" SYMFONY_DEPRECATIONS_HELPER="weak"
         - php: 5.5
+          dist: trusty
           env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" SYMFONY_DEPRECATIONS_HELPER="weak"
 
           # Test the latest stable release
         - php: 5.5
+          dist: trusty
         - php: 5.6
         - php: 7.0
         - php: 7.1
         - php: 7.2
           env: COVERAGE=true PHPUNIT_FLAGS="--coverage-text"
+        - php: 7.3
 
           # Test LTS versions. This makes sure we do not use Symfony packages with version greater
           # than 2 or 3 respectively. Read more at https://github.com/symfony/lts
@@ -37,7 +40,7 @@ matrix:
           env: DEPENDENCIES="dunglas/symfony-lock:^4"
 
           # Latest commit to master
-        - php: 7.2
+        - php: 7.3
           env: STABILITY="dev"
 
     allow_failures:

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "guzzlehttp/psr7": "^1.4",
         "php-http/curl-client": "^1.7",
         "stampie/extra": "^1.0",
-        "symfony/phpunit-bridge": "^4.0",
+        "symfony/phpunit-bridge": "^4.3",
         "nyholm/symfony-bundle-test": "^1.3.1"
     },
     "suggest": {


### PR DESCRIPTION
- force using trusty to run test on PHP 5.5 on Travis, as the default is now xenial which only supports PHP 5.6+
- add testing on PHP 7.3
- force using a recent versions of the phpunit-bridge, as older versions are now unable to install PHPUnit